### PR TITLE
Add cleanup scripts for humanizer-related database tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,23 @@ This repository contains the database schema and setup files for the user regist
 2. Connect to the database using the connection details provided by Railway
 3. Run the schema.sql file to set up the required tables
 
+## Cleanup of Humanizer Tables
+
+A cleanup script has been added to remove any humanizer-related tables from the database:
+
+1. Run the cleanup.js script:
+   ```
+   node cleanup.js
+   ```
+
+2. This will execute the SQL commands in cleanup-humanizer-tables.sql, which:
+   - Drops any humanizer-related tables
+   - Drops any humanizer-related views
+   - Drops any humanizer-related functions
+   - Drops any associated sequences
+
+3. The script will display a list of remaining tables after cleanup for verification
+
 ## Connection Details
 
 When setting up the backend application, you'll need to use the connection details provided by Railway. Railway provides these connection strings as environment variables:

--- a/cleanup-humanizer-tables.sql
+++ b/cleanup-humanizer-tables.sql
@@ -1,0 +1,33 @@
+-- Cleanup script to remove any humanizer-related tables
+
+-- Drop tables if they exist
+DROP TABLE IF EXISTS humanize_requests;
+DROP TABLE IF EXISTS humanize_responses;
+DROP TABLE IF EXISTS humanize_logs;
+DROP TABLE IF EXISTS humanize_stats;
+DROP TABLE IF EXISTS humanize_settings;
+DROP TABLE IF EXISTS ai_detection_results;
+DROP TABLE IF EXISTS api_proxy_logs;
+DROP TABLE IF EXISTS api_proxy_cache;
+
+-- Drop any humanizing-related views
+DROP VIEW IF EXISTS humanize_stats_view;
+DROP VIEW IF EXISTS ai_detection_stats;
+
+-- Drop any functions related to humanizing
+DROP FUNCTION IF EXISTS calculate_humanize_stats();
+DROP FUNCTION IF EXISTS update_humanize_stats();
+DROP FUNCTION IF EXISTS detect_ai_content();
+
+-- If there are any sequences for these tables, drop them too
+DROP SEQUENCE IF EXISTS humanize_requests_id_seq;
+DROP SEQUENCE IF EXISTS humanize_responses_id_seq;
+DROP SEQUENCE IF EXISTS humanize_logs_id_seq;
+DROP SEQUENCE IF EXISTS humanize_stats_id_seq;
+DROP SEQUENCE IF EXISTS humanize_settings_id_seq;
+DROP SEQUENCE IF EXISTS ai_detection_results_id_seq;
+DROP SEQUENCE IF EXISTS api_proxy_logs_id_seq;
+DROP SEQUENCE IF EXISTS api_proxy_cache_id_seq;
+
+-- Commit the changes
+COMMIT;

--- a/cleanup.js
+++ b/cleanup.js
@@ -1,0 +1,61 @@
+/**
+ * This script runs the cleanup SQL file to remove any humanizer-related tables
+ */
+
+const { Client } = require('pg');
+const fs = require('fs');
+const path = require('path');
+
+async function cleanupDatabase() {
+  // Railway provides connection strings as environment variables
+  const connectionString = process.env.DATABASE_URL || process.env.DATABASE_PUBLIC_URL;
+  
+  if (!connectionString) {
+    console.error('Error: No database connection string found. Please check DATABASE_URL or DATABASE_PUBLIC_URL environment variables');
+    process.exit(1);
+  }
+
+  const client = new Client({
+    connectionString,
+    ssl: {
+      rejectUnauthorized: false // Required for Railway Postgres
+    }
+  });
+
+  try {
+    // Connect to the database
+    await client.connect();
+    console.log('Connected to database for cleanup');
+
+    // Read the cleanup SQL file
+    const cleanupFile = path.join(__dirname, 'cleanup-humanizer-tables.sql');
+    const cleanupSql = fs.readFileSync(cleanupFile, 'utf8');
+
+    // Execute the cleanup SQL
+    await client.query(cleanupSql);
+    console.log('Humanizer tables cleanup completed successfully');
+
+    // List remaining tables for verification
+    const { rows } = await client.query(`
+      SELECT table_name 
+      FROM information_schema.tables 
+      WHERE table_schema = 'public'
+      ORDER BY table_name;
+    `);
+    
+    console.log('Remaining tables in the database:');
+    rows.forEach(row => {
+      console.log(`- ${row.table_name}`);
+    });
+
+  } catch (err) {
+    console.error('Error cleaning up database:', err);
+  } finally {
+    // Close the connection
+    await client.end();
+    console.log('Database connection closed');
+  }
+}
+
+// Run the cleanup
+cleanupDatabase();


### PR DESCRIPTION
## Purpose

This PR adds scripts to clean up any humanizer-related tables in the PostgreSQL database.

## Changes Made

1. **Added SQL cleanup script**:
   - Created `cleanup-humanizer-tables.sql` to drop any humanizer-related:
     - Tables
     - Views
     - Functions
     - Sequences

2. **Added JavaScript runner**:
   - Created `cleanup.js` to execute the SQL script
   - Includes logic to display remaining tables after cleanup
   - Uses the same connection approach as setup.js

3. **Updated README**:
   - Added a section on how to run the cleanup script
   - Provided details on what the cleanup does

## Usage

To clean up the database, run:
```
node cleanup.js
```

This will remove any humanizer-related database objects while leaving the core user registration system intact.